### PR TITLE
fix: remove unnecessary image proxying

### DIFF
--- a/src/store/jettons/manager/providers/ton.ts
+++ b/src/store/jettons/manager/providers/ton.ts
@@ -72,7 +72,6 @@ export class TonProvider extends BaseProvider {
       metadata: {
         ...metadata,
         decimals,
-        image: metadata?.image && proxyMedia(metadata.image, 512, 512),
       },
       walletAddress,
       balance: fromNano(jettonBalance.balance, decimals),

--- a/src/store/nfts/manager/providers/ton.ts
+++ b/src/store/nfts/manager/providers/ton.ts
@@ -133,10 +133,7 @@ export class TonProvider extends BaseProvider {
         ? nft.metadata.name.trim()
         : nft.metadata?.name;
 
-    const baseUrl =
-      (nft.previews &&
-        nft.previews.find((preview) => preview.resolution === '500x500').url) ||
-      (nft.metadata?.image && proxyMedia(nft.metadata?.image, 512, 512));
+    const baseUrl = nft.previews?.find((preview) => preview.resolution === '500x500')?.url;
 
     return {
       ...nft,


### PR DESCRIPTION
Tonapi returns URL of already cached media