### PR TITLE
fix: jetton forward amount payload

### DIFF
--- a/src/blockchain/wallet.ts
+++ b/src/blockchain/wallet.ts
@@ -346,7 +346,7 @@ export class TonWallet {
       toAddress: new TonWeb.utils.Address(address),
       responseAddress: new TonWeb.utils.Address(await this.getAddress()),
       jettonAmount: new TonWeb.utils.BN(amount, 10),
-      forwardAmount: new TonWeb.utils.BN(1, 10),
+      forwardAmount: new TonWeb.utils.BN(50000000, 10),
       forwardPayload: payloadCell.bits.getTopUppedArray(),
     });
 
@@ -413,7 +413,7 @@ export class TonWallet {
       toAddress: new TonWeb.utils.Address(address),
       responseAddress: new TonWeb.utils.Address(await this.getAddress()),
       jettonAmount: jettonAmount,
-      forwardAmount: new TonWeb.utils.BN(1, 10),
+      forwardAmount: new TonWeb.utils.BN(50000000, 10),
       forwardPayload: payloadCell.bits.getTopUppedArray(),
     });
 


### PR DESCRIPTION
Without this fix, it is impossible to process the receipt of tokens from Tonkeeper automatically with a smart contract, since the gas on recv_internal with the op-code transfer_notification is too limited.

Proof:
https://ton.cx/tx/33513435000007:KY2AT6AsoQO6xjBmjnN+U8S8m6YVCwZ9b6yj6JzjSNY=:EQCqBBmCVouV1Vbrng3DCjT92Ozs8iDZapDNBDlhr8VsEc5m